### PR TITLE
objectDelete should return StatusNoContent instead of plain 200

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -528,7 +528,9 @@ func (s *Server) deleteObject(r *http.Request) jsonResponse {
 	} else {
 		s.eventManager.Trigger(&backendObj, notification.EventDelete, nil)
 	}
-	return jsonResponse{}
+	return jsonResponse{
+		status: http.StatusNoContent,
+	}
 }
 
 func (s *Server) listObjectACL(r *http.Request) jsonResponse {


### PR DESCRIPTION
In the real API, google returns a 204 after deleting an object. This updates the mock server to return 204 instead of 200.